### PR TITLE
Improve accessibility and UX across the application

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -47,13 +47,13 @@ function App() {
             setInputDisabled(false);
           }}
         />
-        <div className={containerClasses}>
+        <main className={containerClasses}>
           <ColorSelection
             handleFallingColorChange={handleFallingColorChange}
             handleLandedColorChange={handleLandedColorChange}
           />
           <Game inputDisabled={inputDisabled} />
-        </div>
+        </main>
       </settingsContext.Provider>
     </div>
   )

--- a/src/components/color-selection/ColorPickerWithSwatches.tsx
+++ b/src/components/color-selection/ColorPickerWithSwatches.tsx
@@ -33,7 +33,8 @@ export default function ColorPickerWithSwatches({color, onChangeColor, swatches}
         return <button
           key={JSON.stringify(swatch)}
           onClick={() => handleSwatchSelect(swatch)}
-          className="aspect-square w-1/12 m-1 rounded-sm"
+          aria-label={`Select color ${swatch}`}
+          className="aspect-square w-1/12 min-w-11 min-h-11 m-1 rounded-sm"
           style={{background: swatch}}
         />
       })}

--- a/src/components/color-selection/SwapButton.tsx
+++ b/src/components/color-selection/SwapButton.tsx
@@ -3,7 +3,7 @@ interface SwapButtonProps {
 }
 
 export default function SwapButton({handleSwap}: SwapButtonProps) {
-  return <button onClick={handleSwap} className="w-1/2 py-2 shadow-xl rounded-md bg-info-bg hover:bg-button-hover text-text-dark hover:text-button-hover-text">
+  return <button onClick={handleSwap} aria-label="Swap falling and landed block colors" className="w-1/2 py-2 shadow-xl rounded-md bg-info-bg hover:bg-button-hover text-text-dark hover:text-button-hover-text">
       <div className="flex gap-2 justify-center">
         <SwapIcon /> Swap
       </div>

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -34,7 +34,7 @@ function getCellColor(
 ): string {
   return isFallingBlock ? fallingColorHex : (
     isLandedBlock ? landedColorHex : (
-      (isGhostBlock && showGhostBlock) ? "rgba(50%, 50%, 50%, 50%)" : "transparent"
+      (isGhostBlock && showGhostBlock) ? "rgba(60%, 60%, 60%, 60%)" : "transparent"
     )
   );
 }
@@ -44,7 +44,7 @@ export default function Board({ gameState, handleRestart }: BoardProps) {
   const fallingBlockPosition = gameState.currentBlockPosition;
   const currentBlockRotation = getRotationArray(gameState.nextBlocks[0]);
 
-  return <div id="board" className="touch-none relative w-64 h-fit rounded-md md:rounded-none md:rounded-bl-md overflow-hidden bg-board-bg">
+  return <div id="board" role="img" aria-label="Tetris game board" className="touch-none relative w-64 h-fit rounded-md md:rounded-none md:rounded-bl-md overflow-hidden bg-board-bg">
     <GameOverlay isOpen={gameState.isPaused}>
       <p className="text-center">Paused!</p>
       <p className="text-center">(ESC to resume)</p>
@@ -99,7 +99,7 @@ function GameOverlay({ isOpen, children }: { isOpen: boolean; children: ReactNod
 
 function GameOverModal({isOpen, handleRestart}: { isOpen: boolean, handleRestart: () => void }) {
   return <GameOverlay isOpen={isOpen}>
-      <p>Game Over!</p>
+      <p role="alert">Game Over!</p>
       <button onClick={handleRestart}
               className="bg-info-bg text-text-dark hover:bg-button-hover hover:text-button-hover-text shadow-md rounded-md p-1"
       >Restart</button>

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -49,18 +49,31 @@ export default function Game({ inputDisabled }: { inputDisabled: boolean }) {
     localStorage.setItem(HIGH_SCORE_KEY, Math.max(gameState.score, +HIGH_SCORE).toString())
   }, [isOver]);
 
-  return (<div className="flex flex-row justify-start drop-shadow-md shadow-background">
-    <HoldBlock heldBlock={gameState.heldBlock}
-               color={fallingColorHex}
-               score={gameState.score}
-               hiScore={+HIGH_SCORE}
-               level={level}
-    />
-    <Board gameState={gameState}
-           handleRestart={() => dispatch(GameStateAction.RESTART)}
-    />
-    <Info blockColor={fallingColorHex}
-          nextBlocks={gameState.nextBlocks.slice(1)}
-    />
-  </div>)
+  return (<>
+    <div aria-live="polite" className="sr-only">
+      {gameState.isOver ? "Game over." :
+       gameState.isPaused ? "Game paused." :
+       `Level ${level}, Score ${gameState.score}`}
+    </div>
+    <div className="flex flex-col items-center">
+      <div className="flex md:hidden justify-between w-64 px-3 py-1 bg-info-bg rounded-t-md text-text-dark text-sm">
+        <span>Lv {level}</span>
+        <span>Score: {gameState.score}</span>
+      </div>
+      <div className="flex flex-row justify-start drop-shadow-md shadow-background">
+        <HoldBlock heldBlock={gameState.heldBlock}
+                   color={fallingColorHex}
+                   score={gameState.score}
+                   hiScore={+HIGH_SCORE}
+                   level={level}
+        />
+        <Board gameState={gameState}
+               handleRestart={() => dispatch(GameStateAction.RESTART)}
+        />
+        <Info blockColor={fallingColorHex}
+              nextBlocks={gameState.nextBlocks.slice(1)}
+        />
+      </div>
+    </div>
+  </>)
 }

--- a/src/components/game/HoldBlock.tsx
+++ b/src/components/game/HoldBlock.tsx
@@ -11,7 +11,7 @@ interface HoldBlockProps {
 }
 
 export default function HoldBlock({ heldBlock, color, level, score, hiScore }: HoldBlockProps) {
-  return <div className="hidden md:flex flex-col align-middle w-32 rounded-l-md p-3 h-fit bg-info-bg">
+  return <aside aria-label="Game statistics" className="hidden md:flex flex-col align-middle w-32 rounded-l-md p-3 h-fit bg-info-bg">
     <p className="text-text-dark text-center uppercase">Held</p>
     <div className="m-1 p-2 bg-board-bg rounded-md overflow-hidden">
       <BlockPreview block={heldBlock} color={color} />
@@ -21,5 +21,5 @@ export default function HoldBlock({ heldBlock, color, level, score, hiScore }: H
       <InfoBox label={"Score"} value={score} />
       <InfoBox label={"High Score"} value={hiScore} />
     </div>
-  </div>
+  </aside>
 }

--- a/src/components/game/Info.tsx
+++ b/src/components/game/Info.tsx
@@ -7,7 +7,7 @@ interface InfoProps {
 }
 
 export default function Info({nextBlocks, blockColor}: InfoProps) {
-  return <div className="hidden md:flex flex-col align-middle w-32 rounded-r-md bg-info-bg">
+  return <aside aria-label="Next blocks" className="hidden md:flex flex-col align-middle w-32 rounded-r-md bg-info-bg">
     <NextBlocks blocks={nextBlocks} color={blockColor} />
-  </div>
+  </aside>
 }

--- a/src/components/game/InfoBox.tsx
+++ b/src/components/game/InfoBox.tsx
@@ -1,6 +1,6 @@
 export default function InfoBox({ label, value }: { label: string; value: number }) {
-  return (<div className="text-text-dark m-3 flex flex-col max-w-20">
-    <p className="">{label}</p>
-    <div className="px-1 rounded-md text-right bg-board-bg">{value}</div>
-  </div>)
+  return (<dl className="text-text-dark m-3 max-w-20">
+    <dt>{label}</dt>
+    <dd className="px-1 rounded-md text-right bg-board-bg">{value}</dd>
+  </dl>)
 }

--- a/src/components/game/Modal.tsx
+++ b/src/components/game/Modal.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, useEffect, useRef, PointerEvent} from "react";
+import {ReactNode, useEffect, useId, useRef, PointerEvent} from "react";
 
 interface ModalProps {
   children: ReactNode;
@@ -9,17 +9,19 @@ interface ModalProps {
 
 export default function Modal({children, title, isOpen, handleClose}: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
 
   function closeDialog() {
     handleClose();
     dialogRef.current?.close();
+    previousFocusRef.current?.focus();
   }
 
   useEffect(() => {
-    const currentRef = dialogRef.current;
-
     if (isOpen) {
-      currentRef?.showModal();
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      dialogRef.current?.showModal();
     }
   }, [isOpen, handleClose]);
 
@@ -33,14 +35,18 @@ export default function Modal({children, title, isOpen, handleClose}: ModalProps
 
   return <dialog
     ref={dialogRef}
+    aria-labelledby={titleId}
     className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 shadow-2xl rounded-md"
     onPointerDown={handlePointerDown}
-    onClose={handleClose}
+    onClose={() => {
+      handleClose();
+      previousFocusRef.current?.focus();
+    }}
   >
     <div className="dialog-modal flex flex-col bg-header">
       <div className="flex flex-row-reverse justify-between w-full p-1 border-b-1 border-background">
-        <button className="w-fit hover:text-button-hover-text text-text text-center hover:bg-button-hover rounded-md p-2 aspect-square" onClick={closeDialog}><CloseIcon /></button>
-        <h2 className="text-center text-xl text-text pt-1 pl-2">{title}</h2>
+        <button aria-label="Close" className="w-fit hover:text-button-hover-text text-text text-center hover:bg-button-hover rounded-md p-2 aspect-square" onClick={closeDialog}><CloseIcon /></button>
+        <h2 id={titleId} className="text-center text-xl text-text pt-1 pl-2">{title}</h2>
       </div>
       {children}
     </div>

--- a/src/components/game/header/ColorModeSwitch.tsx
+++ b/src/components/game/header/ColorModeSwitch.tsx
@@ -23,7 +23,7 @@ export default function ColorModeSwitch() {
   const [theme, toggleTheme] = useDarkMode();
 
   return <div>
-    <button className="cursor-pointer" onClick={toggleTheme}>
+    <button className="cursor-pointer p-2" onClick={toggleTheme} aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}>
       <Icon isDark={theme === "dark"} />
     </button>
   </div>

--- a/src/components/game/header/Github.tsx
+++ b/src/components/game/header/Github.tsx
@@ -2,7 +2,9 @@ export default function Github() {
   return <div>
     <a href="https://github.com/batistan/react-dichoptic-tetris"
        target="_blank"
-       rel="noopener noreferrer">
+       rel="noopener noreferrer"
+       aria-label="View source on GitHub"
+       className="p-2 inline-block">
       <Icon />
     </a>
   </div>

--- a/src/components/game/header/Header.tsx
+++ b/src/components/game/header/Header.tsx
@@ -9,11 +9,11 @@ export function Header(
 
   return <header className="p-3 flex flex-row justify-between bg-header shadow-md">
     <h1 className="text-xl">Dichoptic Tetris</h1>
-    <div className="flex justify-between gap-2">
+    <nav aria-label="Site controls" className="flex justify-between gap-2">
       <Tutorial handleModalOpen={handleModalOpen} handleModalClose={handleModalClose} />
       <Settings handleModalOpen={handleModalOpen} handleModalClose={handleModalClose} />
       <ColorModeSwitch />
       <Github />
-    </div>
+    </nav>
   </header>
 }

--- a/src/components/game/header/HeaderPopup.tsx
+++ b/src/components/game/header/HeaderPopup.tsx
@@ -16,7 +16,7 @@ export default function HeaderPopup(
   const [open, setOpen] = useState(false);
 
   return <div>
-    <button className="cursor-pointer" onClick={() => {
+    <button className="cursor-pointer p-2" aria-label={modalTitle} onClick={() => {
     handleModalOpen()
     setOpen(true)
   }}>{icon}</button>

--- a/src/components/game/header/Settings.tsx
+++ b/src/components/game/header/Settings.tsx
@@ -57,7 +57,8 @@ export default function Settings(
           <input
             name="fallingColor"
             type="text"
-            className="font-mono uppercase w-1/4 bg-background px-1 text-right"
+            aria-invalid={!fallingColorHex.match(hexColorRegex) || undefined}
+            className={`font-mono uppercase w-1/4 bg-background px-1 text-right rounded-sm ${!fallingColorHex.match(hexColorRegex) ? "border-2 border-red-400" : ""}`}
             value={fallingColorHex}
             onChange={(e) => setFallColor(e.target.value)}
           />
@@ -66,7 +67,8 @@ export default function Settings(
           <input
             name="landedColor"
             type="text"
-            className="font-mono uppercase w-1/4 bg-background px-1 text-right"
+            aria-invalid={!landedColorHex.match(hexColorRegex) || undefined}
+            className={`font-mono uppercase w-1/4 bg-background px-1 text-right rounded-sm ${!landedColorHex.match(hexColorRegex) ? "border-2 border-red-400" : ""}`}
             value={landedColorHex}
             onChange={(e) => setLandedColor(e.target.value)}
           />

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,17 @@ body, html, #root {
   margin: 0;
   height: 100%;
 }
+
+*:focus-visible {
+  outline: 2px solid var(--color-primary-5);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

- **Keyboard accessibility**: Add global `focus-visible` outline so keyboard users can see which element has focus
- **Screen reader support**: Add ARIA labels to all icon-only buttons, `aria-live` region for game state announcements (score, level, pause, game over), `aria-labelledby` on modals, `role="alert"` on game over
- **Semantic HTML**: Replace generic `<div>` elements with `<main>`, `<aside>`, `<nav>`, `<dl>`/`<dt>`/`<dd>` for proper document structure and landmark navigation
- **Modal focus management**: Capture focus on open, restore focus to trigger button on close
- **Mobile UX**: Add compact info bar showing level and score above the board (previously hidden on mobile)
- **Touch targets**: Increase header button and color swatch tap areas to meet 44px WCAG minimum
- **Form validation**: Show red border and `aria-invalid` on invalid hex color inputs in Settings
- **Motion sensitivity**: Add `prefers-reduced-motion` media query to disable animations/transitions
- **Ghost block contrast**: Increase opacity from 50% to 60% for better visibility

## Test plan

- [ ] Tab through all interactive elements — blue focus ring should be visible on each
- [ ] Open Settings/About modals via keyboard, then close — focus should return to the trigger button
- [ ] View on mobile viewport — level and score bar should appear above the board
- [ ] Enter invalid hex color in Settings — red border should appear on the input
- [ ] Verify build passes (`npm run build`) and no new lint errors (`npm run lint`)

https://claude.ai/code/session_01AzKbyQJmGpm9xWaCqAmCgy